### PR TITLE
Improve signal handling for kdewallet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 		<!-- runtime dependencies -->
 		<api.version>0.1.3</api.version>
 		<secret-service.version>1.2.1</secret-service.version>
-		<kdewallet.version>1.1.1</kdewallet.version>
+		<kdewallet.version>1.2.0</kdewallet.version>
 		<guava.version>30.0-jre</guava.version>
 		<slf4j.version>1.7.30</slf4j.version>
 	</properties>

--- a/src/main/java/org/cryptomator/linux/keychain/KDEWalletKeychainAccess.java
+++ b/src/main/java/org/cryptomator/linux/keychain/KDEWalletKeychainAccess.java
@@ -28,6 +28,7 @@ public class KDEWalletKeychainAccess implements KeychainAccessProvider, Property
 		try {
 			DBusConnection conn = DBusConnection.getConnection(DBusConnection.DBusBusType.SESSION);
 			wallet = new ConnectedWallet(conn);
+			wallet.wallet.getSignalHandler().addPropertyChangeListener(this);
 		} catch (DBusException e) {
 			LOG.warn("Connecting to D-Bus failed.", e);
 		}

--- a/src/main/java/org/cryptomator/linux/keychain/KDEWalletKeychainAccess.java
+++ b/src/main/java/org/cryptomator/linux/keychain/KDEWalletKeychainAccess.java
@@ -69,7 +69,9 @@ public class KDEWalletKeychainAccess implements KeychainAccessProvider, Property
 		if (event.getPropertyName().equals("KWallet.walletAsyncOpened")) {
 			Preconditions.checkState(wallet.isPresent(), "Keychain not supported.");
 			wallet.get().handle = (int) event.getNewValue();
-			LOG.info("Wallet successfully initialized.");
+			if (wallet.get().handle != -1) {
+				LOG.info("Wallet successfully opened.");
+			}
 		}
 	}
 


### PR DESCRIPTION
D-Bus signals are emitted on every change to a wallet, e.g. when it's opened asynchronously, closed etc.. Cryptomator checks for these signals and processes them.
Signal handling in ‪kdewallet does work well [1], but could be improved in some regards:
- the `SignalHandler#await` method keeps the running application in a loop and waits for the signal to listen for until the signal was emitted or a timeout is reached 
- you cannot await a signal and execute the code that emits the signal afterwards
- the `SignalHandler` does not support to catch signals asynchronously

kdewallet 1.2.0 solves this by providing a re-designed `SignalHandler` to handle signals asynchronously and make `SignalHandler` more robust against timed out D-Bus calls.

To make use of the new features, integrations-linux needs slight changes. And that’s the motivation for this PR.

Here is what happens in Cryptomator without and with this change:
`SignalHandler` in kdewallet 1.1.1:
```
06:38:39.286 [App Scheduled Executor 01] INFO  o.c.common.settings.SettingsProvider - Settings saved to /home/ralph/.config/Cryptomator/settings.json
06:38:41.821 [JavaFX Application Thread] INFO  o.f.dbus.handlers.SignalHandler - Await signal org.kde.KWallet$walletAsyncOpened(/modules/kwalletd5) within 120 seconds.
06:38:46.520 [DBus Worker Thread-4] INFO  o.f.dbus.handlers.SignalHandler - Received signal KWallet.walletOpened: kdewallet
06:38:46.521 [DBus Worker Thread-1] INFO  o.f.dbus.handlers.SignalHandler - Received signal KWallet.walletAsyncOpened: {TransactionID: 0, handle: 248503178}
06:38:53.330 [App Background Thread 005] INFO  org.cryptomator.common.vaults.Vault - Storing file name length limit of 220
06:38:54.331 [App Scheduled Executor 02] INFO  o.c.common.settings.SettingsProvider - Settings saved to /home/ralph/.config/Cryptomator/settings.json
06:38:55.621 [App Background Thread 005] INFO  o.c.ui.unlock.UnlockWorkflow - Unlock of 'Test' succeeded.
06:38:55.625 [DBus Worker Thread-1] INFO  o.f.dbus.handlers.SignalHandler - Received signal KWallet.folderUpdated: {wallet: kdewallet, folder: Cryptomator}
```

`SignalHandler` in kdewallet 1.2.0:
```
07:23:25.510 [App Scheduled Executor 01] INFO  o.c.common.settings.SettingsProvider - Settings saved to /home/ralph/.config/Cryptomator/settings.json
07:23:28.945 [DBus Worker Thread-3] INFO  o.c.l.k.KDEWalletKeychainAccess - Wallet successfully opened.
07:23:28.945 [DBus Worker Thread-2] INFO  o.f.dbus.handlers.SignalHandler - Received signal KWallet.walletOpened: kdewallet
07:23:28.945 [DBus Worker Thread-3] INFO  o.f.dbus.handlers.SignalHandler - Received signal KWallet.walletAsyncOpened: {TransactionID: 0, handle: 389267065}
07:23:48.265 [App Background Thread 004] INFO  org.cryptomator.common.vaults.Vault - Storing file name length limit of 220
07:23:49.266 [App Scheduled Executor 02] INFO  o.c.common.settings.SettingsProvider - Settings saved to /home/ralph/.config/Cryptomator/settings.json
07:23:50.589 [App Background Thread 004] INFO  o.c.ui.unlock.UnlockWorkflow - Unlock of 'Test' succeeded.
07:23:50.593 [DBus Worker Thread-3] INFO  o.f.dbus.handlers.SignalHandler - Received signal KWallet.folderUpdated: {wallet: kdewallet, folder: Cryptomator}
```

[1] the current kdewallet implementation within the integrations-api does work without this PR