### PR TITLE
added checks for system-only DBus

### DIFF
--- a/src/main/java/org/cryptomator/linux/keychain/KDEWalletKeychainAccess.java
+++ b/src/main/java/org/cryptomator/linux/keychain/KDEWalletKeychainAccess.java
@@ -24,7 +24,15 @@ public class KDEWalletKeychainAccess implements KeychainAccessProvider {
 	public KDEWalletKeychainAccess() {
 		ConnectedWallet wallet = null;
 		try {
-			DBusConnection conn = DBusConnection.getConnection(DBusConnection.DBusBusType.SESSION);
+			DBusConnection conn = null;
+			try {
+				conn = DBusConnection.getConnection(DBusConnection.DBusBusType.SESSION);
+			} catch (RuntimeException e) {
+				LOG.warn("SESSION DBus not found.", e);
+			}
+			if(conn == null){
+				conn = DBusConnection.getConnection(DBusConnection.DBusBusType.SYSTEM);
+			}
 			wallet = new ConnectedWallet(conn);
 		} catch (DBusException e) {
 			LOG.warn("Connecting to D-Bus failed.", e);

--- a/src/main/java/org/cryptomator/linux/keychain/KDEWalletKeychainAccess.java
+++ b/src/main/java/org/cryptomator/linux/keychain/KDEWalletKeychainAccess.java
@@ -28,9 +28,11 @@ public class KDEWalletKeychainAccess implements KeychainAccessProvider {
 			try {
 				conn = DBusConnection.getConnection(DBusConnection.DBusBusType.SESSION);
 			} catch (RuntimeException e) {
-				LOG.warn("SESSION DBus not found.", e);
+				if (e.getMessage() == "Cannot Resolve Session Bus Address") {
+					LOG.warn("SESSION DBus not found.");
+				}
 			}
-			if(conn == null){
+			if (conn == null) {
 				conn = DBusConnection.getConnection(DBusConnection.DBusBusType.SYSTEM);
 			}
 			wallet = new ConnectedWallet(conn);

--- a/src/main/java/org/cryptomator/linux/keychain/SecretServiceKeychainAccess.java
+++ b/src/main/java/org/cryptomator/linux/keychain/SecretServiceKeychainAccess.java
@@ -18,7 +18,7 @@ public class SecretServiceKeychainAccess implements KeychainAccessProvider {
 		try (@SuppressWarnings("unused") SimpleCollection keyring = new SimpleCollection()) {
 			// seems like we're able to access the keyring.
 			return true;
-		} catch (IOException | RuntimeException e) {
+		} catch (IOException | ExceptionInInitializerError | RuntimeException e) {
 			return false;
 		}
 	}


### PR DESCRIPTION
I run a Linux distribution that doesn't implement a session DBus, but does have a system-wide DBus. This change simply checks if the DBus connection fails and tries to connect to the system DBus. The ExceptionInInitializerError exception is also thrown by the SecretServiceKeychain because of this. I added that check to notify that it isn't supported. 
It fixes this issue for me https://github.com/cryptomator/cryptomator/issues/1479