### PR TITLE
Refactor DBus Connection Initialization - secret-service

### DIFF
--- a/src/main/java/org/cryptomator/linux/keychain/SecretServiceKeychainAccess.java
+++ b/src/main/java/org/cryptomator/linux/keychain/SecretServiceKeychainAccess.java
@@ -24,7 +24,7 @@ public class SecretServiceKeychainAccess implements KeychainAccessProvider {
 		try (@SuppressWarnings("unused") SimpleCollection keyring = new SimpleCollection()) {
 			// seems like we're able to access the keyring.
 			return keyring.isLocked();
-		} catch (IOException | ExceptionInInitializerError | RuntimeException e) {
+		} catch (IOException e) {
 			return true;
 		}
 	}


### PR DESCRIPTION
Belongs to https://github.com/cryptomator/integrations-linux/pull/9

Note: the current secret-service dependency in the pom is 1.5.0, which does depend on dbus-java 3.2.4.
Before merging, the  secret-service dependency in the pom needs to be updated to a version that depends on dbus-java 3.3.0.