### PR TITLE
Update kdewallet to 1.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
 		<api.version>1.3.0-beta1</api.version>
 		<secret-service.version>1.8.1-jdk17</secret-service.version>
-		<kdewallet.version>1.3.0</kdewallet.version>
+		<kdewallet.version>1.3.1</kdewallet.version>
 		<appindicator.version>1.3.0</appindicator.version>
 		<guava.version>32.0.0-jre</guava.version>
 		<slf4j.version>1.7.36</slf4j.version>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 import org.cryptomator.integrations.keychain.KeychainAccessProvider;
 import org.cryptomator.integrations.revealpath.RevealPathService;
 import org.cryptomator.integrations.tray.TrayMenuController;
+import org.cryptomator.linux.keychain.KDEWalletKeychainAccess;
 import org.cryptomator.linux.keychain.SecretServiceKeychainAccess;
 import org.cryptomator.linux.revealpath.DBusSendRevealPathService;
 import org.cryptomator.linux.tray.AppindicatorTrayMenuController;
@@ -15,7 +16,7 @@ module org.cryptomator.integrations.linux {
 	requires org.purejava.kwallet;
 	requires secret.service;
 
-	provides KeychainAccessProvider with SecretServiceKeychainAccess;
+	provides KeychainAccessProvider with SecretServiceKeychainAccess, KDEWalletKeychainAccess;
 	provides RevealPathService with DBusSendRevealPathService;
 	provides TrayMenuController with AppindicatorTrayMenuController;
 

--- a/src/main/java/org/cryptomator/linux/keychain/KDEWalletKeychainAccess.java
+++ b/src/main/java/org/cryptomator/linux/keychain/KDEWalletKeychainAccess.java
@@ -10,7 +10,7 @@ import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder;
 import org.freedesktop.dbus.exceptions.DBusConnectionException;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
-import org.kde.KWallet;
+import org.purejava.kwallet.KWallet;
 import org.purejava.kwallet.KDEWallet;
 import org.purejava.kwallet.Static;
 import org.slf4j.Logger;


### PR DESCRIPTION
This updates `kdewallet` to the current version and re-enables the `kdewallet` functionality in `integrations-linux`.

As the 'split jar' problem [arose for the first time](https://github.com/cryptomator/cryptomator/pull/2885#issuecomment-1529048158), I released kdewallet `1.3.0` to fix it, but with it, not all classes of `kdewallet` were moved to a namespace controlled by the author, as the package name of the Java interface needs to follow the interface name of the D-Bus interface. By using `@DBusInterfaceName`, all interfaces _can_ be moved to a namespace controlled by the author and thus fully avoid 'split jar' problems. This is done with kdewallet `1.3.1`.

Implementing the libappindicator features for `integrations-linux` made it necessary to have a `module-info.java`. It currently lacks a `KeychainAccessProvider` for `kdewallet` to make `kdewallet` functionality available for Cryptomator.

Both problems are addressed with this PR.