### PR TITLE
Use version 1.3.3 of appindicator-gtk3-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.cryptomator</groupId>
 	<artifactId>integrations-linux</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.0-beta5</version>
 
 	<name>integrations-linux</name>
 	<description>Provides optional Linux services used by Cryptomator</description>
@@ -43,7 +43,7 @@
 		<api.version>1.3.0-beta1</api.version>
 		<secret-service.version>1.8.1-jdk17</secret-service.version>
 		<kdewallet.version>1.3.1</kdewallet.version>
-		<appindicator.version>1.3.2</appindicator.version>
+		<appindicator.version>1.3.3</appindicator.version>
 		<guava.version>32.0.0-jre</guava.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<commons-lang3.version>3.12.0</commons-lang3.version>


### PR DESCRIPTION
This changes library loading of the Java bindings. It uses `System.load` now, which makes the use of LD_LIBRARY_PATH obsolete for the AppImage and the ppa.