### PR TITLE
Update kdewallet to 1.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
 		<api.version>1.3.0-beta1</api.version>
 		<secret-service.version>1.8.1-jdk17</secret-service.version>
-		<kdewallet.version>1.3.1</kdewallet.version>
+		<kdewallet.version>1.3.2</kdewallet.version>
 		<appindicator.version>1.3.0</appindicator.version>
 		<guava.version>32.0.0-jre</guava.version>
 		<slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
Closes https://github.com/cryptomator/cryptomator/issues/3020.

Up to version 1.3.1 of kdewallet, the code contains a shutdown hook, that gets triggered on shutdown of the JVM and performs a clean-up.

This clean-up unregisters the D-Bus signals relevant for and registered to kdewallet.

Nevertheless, the clean-up can fail when the D-Bus connection is already closed.

Furthermore, the clean-up is not needed, as dbus-java does the clean-up.

This PR updates the dependency to kdewallet 1.3.2, where the shutdown hook and the clean-up were removed.