### PR TITLE
Update kdewallet to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
 		<api.version>1.3.0</api.version>
 		<secret-service.version>2.0.0-alpha</secret-service.version>
-		<kdewallet.version>1.3.3</kdewallet.version>
+		<kdewallet.version>1.4.0</kdewallet.version>
 		<appindicator.version>1.3.6</appindicator.version>
 		<slf4j.version>2.0.9</slf4j.version>
 


### PR DESCRIPTION
I noticed that development for KDE Framework 6 (aka KF6) / QT6 is proceeding, and more and more packages are making the transition.

`kwallet` is already available for KF6 [on some distros](https://pkgs.org/download/kf6-kwallet), so I thought it might be a good idea to make `kdewallet` compatible to it.

Besides that, maven dependencies and github workflow actions were updated with release `1.4.0`. Release `1.4.0` is backwards compatible to KDE Framework 5.

There's no hurry to merge that PR.