### PR TITLE
Update kdewallet to 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
 		<api.version>1.3.0</api.version>
 		<secret-service.version>2.0.0-alpha</secret-service.version>
-		<kdewallet.version>1.3.3</kdewallet.version>
+		<kdewallet.version>1.5.0</kdewallet.version>
 		<appindicator.version>1.3.6</appindicator.version>
 		<slf4j.version>2.0.11</slf4j.version>
 


### PR DESCRIPTION
Compared to version 1.4.0, it has the following changes:
- Update to dbus-java 5.0.0
- Update maven dependencies

Version 1.5.0 has the following changes, compared to 1.3.3:
- Update to dbus-java 5.0.0
- Compatibility to KWallet Frameworks 5 & 6
- Update maven dependencies

Superseeds https://github.com/cryptomator/integrations-linux/pull/52.