### PR TITLE
TrayMenuController API: Add support for active/inactive tray menu entries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<secret-service.version>2.0.1-alpha</secret-service.version>
 		<kdewallet.version>1.4.0</kdewallet.version>
 		<slf4j.version>2.0.13</slf4j.version>
-		<appindicator.version>1.4.0</appindicator.version>
+		<appindicator.version>1.4.1</appindicator.version>
 
 		<!-- test dependencies -->
 		<junit.version>5.10.2</junit.version>

--- a/src/main/java/org/cryptomator/linux/tray/AppindicatorTrayMenuController.java
+++ b/src/main/java/org/cryptomator/linux/tray/AppindicatorTrayMenuController.java
@@ -102,6 +102,7 @@ public class AppindicatorTrayMenuController implements TrayMenuController {
 							GCallback.allocate(new ActionItemCallback(a), ARENA),
 							menu,
 							0);
+					Gtk.widgetSetSensitive(gtkMenuItem, a.enabled());
 					Gtk.menuShellAppend(menu, gtkMenuItem);
 				}
 				case SeparatorItem _ -> {


### PR DESCRIPTION
Sets the "Lock All" entry in the tray menu insensitive, with all vaults being locked
Fixes https://github.com/cryptomator/cryptomator/issues/3472