### PR TITLE
Update appindicator to 1.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<secret-service.version>2.0.1-alpha</secret-service.version>
 		<kdewallet.version>1.4.0</kdewallet.version>
 		<slf4j.version>2.0.16</slf4j.version>
-		<appindicator.version>1.4.1</appindicator.version>
+		<appindicator.version>1.4.2</appindicator.version>
 
 		<!-- test dependencies -->
 		<junit.version>5.11.4</junit.version>


### PR DESCRIPTION
This version makes appindicator compatible with Fedora like distributions, as it loads the library from `/usr/lib64` as well.
Otherwise it's compatible to 1.4.1.