### PR TITLE
Refactors Dolphin quick access integration for robustness - Fixes #3883

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -18,6 +18,7 @@ module org.cryptomator.integrations.linux {
 	requires org.purejava.appindicator;
 	requires org.purejava.kwallet;
 	requires de.swiesend.secretservice;
+	requires java.desktop;
 
 	provides AutoStartProvider with FreedesktopAutoStartService;
 	provides KeychainAccessProvider with GnomeKeyringKeychainAccess, KDEWalletKeychainAccess;

--- a/src/main/java/org/cryptomator/linux/quickaccess/DolphinPlaces.java
+++ b/src/main/java/org/cryptomator/linux/quickaccess/DolphinPlaces.java
@@ -6,18 +6,34 @@ import org.cryptomator.integrations.common.OperatingSystem;
 import org.cryptomator.integrations.common.Priority;
 import org.cryptomator.integrations.quickaccess.QuickAccessService;
 import org.cryptomator.integrations.quickaccess.QuickAccessServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -29,28 +45,28 @@ import java.util.UUID;
 @Priority(90)
 public class DolphinPlaces extends FileConfiguredQuickAccess implements QuickAccessService {
 
+	private static final Logger LOG = LoggerFactory.getLogger(DolphinPlaces.class);
+
 	private static final int MAX_FILE_SIZE = 1 << 20; //1MiB, xml is quite verbose
-	private static final Path PLACES_FILE = Path.of(System.getProperty("user.home"), ".local/share/user-places.xbel");
-	private static final String ENTRY_TEMPLATE = """
-			<bookmark href=\"%s\">
-			 <title>%s</title>
-			 <info>
-			  <metadata owner=\"http://freedesktop.org\">
-			   <bookmark:icon name="drive-harddisk-encrypted"/>
-			  </metadata>
-			  <metadata owner=\"https://cryptomator.org\">
-			  	<id>%s</id>
-			  </metadata>
-			 </info>
-			</bookmark>""";
+	private static final String HOME_DIR = System.getProperty("user.home");
+	private static final String CONFIG_PATH_IN_HOME = ".local/share/";
+	private static final String CONFIG_FILE_NAME = "user-places.xbel";
+	private static final Path PLACES_FILE = Path.of(HOME_DIR,CONFIG_PATH_IN_HOME, CONFIG_FILE_NAME);
 
 	private static final Validator XML_VALIDATOR;
 
 	static {
-		SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
 		try (var schemaDefinition = DolphinPlaces.class.getResourceAsStream("/xbel-1.0.xsd")) {
+
+			SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+			factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
 			Source schemaFile = new StreamSource(schemaDefinition);
 			XML_VALIDATOR = factory.newSchema(schemaFile).newValidator();
+
 		} catch (IOException | SAXException e) {
 			throw new IllegalStateException("Failed to load included XBEL schema definition file.", e);
 		}
@@ -61,29 +77,179 @@ public class DolphinPlaces extends FileConfiguredQuickAccess implements QuickAcc
 		super(PLACES_FILE, MAX_FILE_SIZE);
 	}
 
+	public DolphinPlaces(Path configFilePath) {
+		super(configFilePath.resolve(CONFIG_FILE_NAME), MAX_FILE_SIZE);
+	}
+
 	@Override
 	EntryAndConfig addEntryToConfig(String config, Path target, String displayName) throws QuickAccessServiceException {
+
 		try {
+
 			String id = UUID.randomUUID().toString();
-			//validate
+
+			LOG.trace("Adding bookmark for target: '{}', displayName: '{}', id: '{}'", target, displayName, id);
+
+			// Validate the existing config before modifying it, if it is invalid
+			// we should not modify it.
 			XML_VALIDATOR.validate(new StreamSource(new StringReader(config)));
-			// modify
-			int insertIndex = config.lastIndexOf("</xbel"); //cannot be -1 due to validation; we do not match the whole end tag, since between tag name and closing bracket can be whitespaces
-			var adjustedConfig = config.substring(0, insertIndex) //
-					+ "\n" //
-					+ ENTRY_TEMPLATE.formatted(target.toUri(), escapeXML(displayName), id).indent(1) //
-					+ "\n" //
-					+ config.substring(insertIndex);
-			return new EntryAndConfig(new DolphinPlacesEntry(id), adjustedConfig);
-		} catch (SAXException | IOException e) {
-			throw new QuickAccessServiceException("Adding entry to KDE places file failed.", e);
+
+			Document xmlDocument = loadXmlDocument(config);
+
+			NodeList nodeList = extractBookmarksByPath(target, xmlDocument);
+
+			removeStaleBookmarks(nodeList);
+
+			createBookmark(target, displayName, id, xmlDocument);
+
+			XML_VALIDATOR.validate(new DOMSource(xmlDocument));
+
+			return new EntryAndConfig(new DolphinPlacesEntry(id), documentToString(xmlDocument));
+
+		} catch (SAXException e) {
+			throw new QuickAccessServiceException("Invalid structure in xbel bookmark file", e);
+		} catch (IOException e) {
+			throw new QuickAccessServiceException("Failed reading/writing the xbel bookmark file", e);
 		}
 	}
 
-	private String escapeXML(String s) {
-		return s.replace("&","&amp;") //
-				.replace("<","&lt;") //
-				.replace(">","&gt;");
+	private void removeStaleBookmarks(NodeList nodeList) {
+		for (int k = 0; k < nodeList.getLength() ; k++){
+			nodeList.item(k).getParentNode().removeChild(nodeList.item(k));
+		}
+	}
+
+	private static NodeList extractBookmarksByPath(Path target, Document xmlDocument) throws QuickAccessServiceException {
+
+		try {
+
+			XPathFactory xpathFactory = XPathFactory.newInstance();
+			XPath xpath = xpathFactory.newXPath();
+
+			String expression = "/xbel/bookmark[info/metadata[@owner='https://cryptomator.org']][@href='" + target.toUri() + "']";
+
+			return (NodeList) xpath.compile(expression).evaluate(xmlDocument, XPathConstants.NODESET);
+
+		} catch (Exception e) {
+			throw new QuickAccessServiceException("Failed to extract bookmarks by path", e);
+		}
+	}
+
+	private static NodeList extractBookmarksById(String id, Document xmlDocument) throws QuickAccessServiceException {
+
+		try {
+
+			XPathFactory xpathFactory = XPathFactory.newInstance();
+			XPath xpath = xpathFactory.newXPath();
+
+			String expression = "/xbel/bookmark[info/metadata[@owner='https://cryptomator.org']][info/metadata/id[text()='" + id + "']]";
+
+			return (NodeList) xpath.compile(expression).evaluate(xmlDocument, XPathConstants.NODESET);
+
+		} catch (Exception e) {
+  			throw new QuickAccessServiceException("Failed to extract bookmarks by id", e);
+		}
+	}
+
+	private static Document loadXmlDocument(String config) throws QuickAccessServiceException {
+
+		try {
+
+			DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+
+			builderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			builderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			builderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			builderFactory.setXIncludeAware(false);
+			builderFactory.setExpandEntityReferences(false);
+
+			DocumentBuilder builder = builderFactory.newDocumentBuilder();
+
+			return builder.parse(new ByteArrayInputStream(config.getBytes(StandardCharsets.UTF_8)));
+
+		} catch (Exception e) {
+			throw new QuickAccessServiceException("Failed to parse the xbel bookmark file", e);
+		}
+	}
+
+	private String documentToString(Document xmlDocument) throws QuickAccessServiceException {
+
+		try {
+
+			StringWriter buf = new StringWriter();
+
+			Transformer xform = TransformerFactory.newInstance().newTransformer();
+			xform.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes"); // optional
+			xform.setOutputProperty(OutputKeys.INDENT, "yes"); // optional
+			xform.transform(new DOMSource(xmlDocument), new StreamResult(buf));
+
+			return buf.toString();
+
+		} catch (Exception e) {
+			throw new QuickAccessServiceException("Failed to read document into string", e);
+		}
+	}
+
+	/**
+	 *
+	 * Adds a xml bookmark element to the specified xml document
+	 *
+	 * <pre>{@code
+	 * <bookmark href="file:///home/someuser/folder1/">
+	 *   <title>integrations-linux</title>
+	 *   <info>
+	 *     <metadata owner="http://freedesktop.org">
+	 *       <bookmark:icon name="drive-harddisk-encrypted"/>
+	 *     </metadata>
+	 *     <metadata owner="https://cryptomator.org">
+	 *       <id>sldkf-sadf-sadf-sadf</id>
+	 *     </metadata>
+	 *   </info>
+	 * </bookmark>
+	 * }</pre>
+	 *
+	 * @param target The mount point of the vault
+	 * @param displayName Caption of the vault link in dolphin
+	 * @param xmlDocument The xbel document to which the bookmark should be added
+	 *
+	 * @throws QuickAccessServiceException if the bookmark could not be created
+	 */
+	private void createBookmark(Path target, String displayName, String id, Document xmlDocument) throws QuickAccessServiceException {
+
+		try {
+
+			var bookmark = xmlDocument.createElement("bookmark");
+			var title = xmlDocument.createElement("title");
+			var info = xmlDocument.createElement("info");
+			var metadataBookmark = xmlDocument.createElement("metadata");
+			var metadataOwner = xmlDocument.createElement("metadata");
+			var bookmarkIcon = xmlDocument.createElement("bookmark:icon");
+			var idElem = xmlDocument.createElement("id");
+
+			bookmark.setAttribute("href", target.toUri().toString());
+
+			title.setTextContent(displayName);
+
+			bookmark.appendChild(title);
+			bookmark.appendChild(info);
+
+			info.appendChild(metadataBookmark);
+			info.appendChild(metadataOwner);
+
+			metadataBookmark.appendChild(bookmarkIcon);
+			metadataOwner.appendChild(idElem);
+			metadataBookmark.setAttribute("owner", "http://freedesktop.org");
+
+			bookmarkIcon.setAttribute("name","drive-harddisk-encrypted");
+
+			metadataOwner.setAttribute("owner", "https://cryptomator.org");
+
+			idElem.setTextContent(id);
+			xmlDocument.getDocumentElement().appendChild(bookmark);
+
+		} catch (Exception e) {
+			throw new QuickAccessServiceException("Failed to insert bookmark for target: " + target, e);
+		}
 	}
 
 	private class DolphinPlacesEntry extends FileConfiguredQuickAccessEntry implements QuickAccessEntry {
@@ -96,42 +262,24 @@ public class DolphinPlaces extends FileConfiguredQuickAccess implements QuickAcc
 
 		@Override
 		public String removeEntryFromConfig(String config) throws QuickAccessServiceException {
+
 			try {
-				int idIndex = config.lastIndexOf(id);
-				if (idIndex == -1) {
-					return config; //assume someone has removed our entry, nothing to do
-				}
-				//validate
+
 				XML_VALIDATOR.validate(new StreamSource(new StringReader(config)));
-				//modify
-				int openingTagIndex = indexOfEntryOpeningTag(config, idIndex);
-				var contentToWrite1 = config.substring(0, openingTagIndex).stripTrailing();
 
-				int closingTagEndIndex = config.indexOf('>', config.indexOf("</bookmark", idIndex));
-				var part2Tmp = config.substring(closingTagEndIndex + 1).split("\\A\\v+", 2); //removing leading vertical whitespaces, but no indentation
-				var contentToWrite2 = part2Tmp[part2Tmp.length - 1];
+				Document xmlDocument = loadXmlDocument(config);
 
-				return contentToWrite1 + "\n" + contentToWrite2;
+				NodeList nodeList = extractBookmarksById(id, xmlDocument);
+
+				removeStaleBookmarks(nodeList);
+
+				XML_VALIDATOR.validate(new DOMSource(xmlDocument));
+
+				return documentToString(xmlDocument);
+
 			} catch (IOException | SAXException | IllegalStateException e) {
 				throw new QuickAccessServiceException("Removing entry from KDE places file failed.", e);
 			}
-		}
-
-		/**
-		 * Returns the start index (inclusive)  of the {@link DolphinPlaces#ENTRY_TEMPLATE} entry
-		 * @param placesContent the content of the XBEL places file
-		 * @param idIndex start index (inclusive) of the entrys id tag value
-		 * @return start index of the first bookmark tag, searching backwards from idIndex
-		 */
-		private int indexOfEntryOpeningTag(String placesContent, int idIndex) {
-			var xmlWhitespaceChars = List.of(' ', '\t', '\n');
-			for (char c : xmlWhitespaceChars) {
-				int idx = placesContent.lastIndexOf("<bookmark" + c, idIndex); //with the whitespace we ensure, that no tags starting with "bookmark" (e.g. bookmarkz) are selected
-				if (idx != -1) {
-					return idx;
-				}
-			}
-			throw new IllegalStateException("Found entry id " + id + " in " + PLACES_FILE + ", but it is not a child of <bookmark> tag.");
 		}
 	}
 

--- a/src/main/java/org/cryptomator/linux/quickaccess/FileConfiguredQuickAccess.java
+++ b/src/main/java/org/cryptomator/linux/quickaccess/FileConfiguredQuickAccess.java
@@ -31,6 +31,15 @@ abstract class FileConfiguredQuickAccess implements QuickAccessService {
 		Runtime.getRuntime().addShutdownHook(new Thread(this::cleanup));
 	}
 
+	/**
+	 *
+	 * Adds the vault path to the quickacces config file
+	 *
+	 * @param target The mount point of the vault
+	 * @param displayName Caption of the vault link
+	 * @return A cleanup reference for vault link removal
+	 * @throws QuickAccessServiceException
+	 */
 	@Override
 	public QuickAccessEntry add(Path target, String displayName) throws QuickAccessServiceException {
 		try {

--- a/src/test/java/org/cryptomator/linux/quickaccess/DolphinPlacesTest.java
+++ b/src/test/java/org/cryptomator/linux/quickaccess/DolphinPlacesTest.java
@@ -1,14 +1,173 @@
 package org.cryptomator.linux.quickaccess;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DolphinPlacesTest {
+
+	private static final String UUID_FOLDER_1 = "c4b72799-ca67-4c2e-b727-99ca67dc2e5d";
+	private static final String UUID_FOLDER_1_IDENTICAL = "43c6fdb9-626d-468e-86fd-b9626dc68e04d";
+	private static final String CAPTION_FOLDER_1 = "folder 1";
+	private static final String PATH_FOLDER_1 = "/home/someuser/folder1";
+
+	private static final String RESOURCE_USER_PLACES = "quickaccess/dolphin/user-places.xbel";
+	private static final String RESOURCE_USER_PLACES_MULTIPLE_IDENTICAL = "quickaccess/dolphin/user-places-multiple-identical.xbel";
+	private static final String RESOURCE_USER_PLACES_NOT_WELL_FORMED = "quickaccess/dolphin/user-places-not-well-formed.xbel";
+	private static final String RESOURCE_USER_PLACES_NOT_VALID = "quickaccess/dolphin/user-places-not-valid.xbel";
 
 	@Test
 	@DisplayName("Class can be loaded and object instantiated")
 	public void testInit() {
-		Assertions.assertDoesNotThrow(DolphinPlaces::new);
+		assertDoesNotThrow(() -> { new DolphinPlaces(); });
+	}
+
+	@Test
+	@DisplayName("Adding an identical entry should lead to a replacement of the existing entry")
+	public void addingAnIdenticalEntryShouldLeadToReplacementOfExistingEntry(@TempDir Path tmpdir)  {
+
+		var pathToDoc = loadResourceToDir(RESOURCE_USER_PLACES, tmpdir);
+
+		assertTrue(loadFile(pathToDoc).contains(UUID_FOLDER_1));
+		assertTrue(loadFile(pathToDoc).contains(CAPTION_FOLDER_1));
+
+		assertDoesNotThrow(() -> {
+
+			var entry = new DolphinPlaces(tmpdir).add(Path.of(PATH_FOLDER_1), CAPTION_FOLDER_1);
+
+			assertFalse(loadFile(pathToDoc).contains(UUID_FOLDER_1));
+			assertTrue(loadFile(pathToDoc).contains(CAPTION_FOLDER_1));
+
+			entry.remove();
+		});
+	}
+
+	@Test
+	@DisplayName("Adding an identical entry should lead to a replacement of multiple existing entries")
+	public void addingAnIdenticalEntryShouldLeadToReplacementOfMultipleExistingEntry(@TempDir Path tmpdir)  {
+
+		var pathToDoc = loadResourceToDir(RESOURCE_USER_PLACES_MULTIPLE_IDENTICAL, tmpdir);
+
+		assertEquals(1, countOccurrences(loadFile(pathToDoc),UUID_FOLDER_1));
+		assertEquals(1, countOccurrences(loadFile(pathToDoc),UUID_FOLDER_1_IDENTICAL));
+
+		assertEquals(2, countOccurrences(loadFile(pathToDoc), CAPTION_FOLDER_1));
+
+		assertDoesNotThrow(() -> {
+
+			var entry = new DolphinPlaces(tmpdir).add(Path.of(PATH_FOLDER_1), CAPTION_FOLDER_1);
+
+			assertEquals(0, countOccurrences(loadFile(pathToDoc),UUID_FOLDER_1));
+			assertEquals(0, countOccurrences(loadFile(pathToDoc),UUID_FOLDER_1_IDENTICAL));
+
+			assertEquals(1, countOccurrences(loadFile(pathToDoc), CAPTION_FOLDER_1));
+
+			entry.remove();
+		});
+
+		assertEquals(0, countOccurrences(loadFile(pathToDoc), CAPTION_FOLDER_1));
+	}
+
+	@Test
+	@DisplayName("Adding should not replace if file is not valid")
+	public void addingShouldNotReplaceIfFileIsNotValid(@TempDir Path tmpdir) {
+
+		var pathToDoc = loadResourceToDir(RESOURCE_USER_PLACES_NOT_VALID, tmpdir);
+
+		assertEquals(1, countOccurrences(loadFile(pathToDoc), UUID_FOLDER_1));
+		assertEquals(1, countOccurrences(loadFile(pathToDoc), CAPTION_FOLDER_1));
+
+		assertThrows(Exception.class, () -> {
+
+			new DolphinPlaces(tmpdir).add(Path.of(PATH_FOLDER_1), CAPTION_FOLDER_1);
+
+		});
+
+		assertEquals(1, countOccurrences(loadFile(pathToDoc), UUID_FOLDER_1));
+		assertEquals(1, countOccurrences(loadFile(pathToDoc), CAPTION_FOLDER_1));
+	}
+
+	@Test
+	@DisplayName("Adding should not replace if file is not well formed")
+	public void addingShouldNotReplaceIfFileIsNotWellFormed(@TempDir Path tmpdir) {
+
+		var pathToDoc = loadResourceToDir(RESOURCE_USER_PLACES_NOT_WELL_FORMED, tmpdir);
+
+		assertEquals(1, countOccurrences(loadFile(pathToDoc), UUID_FOLDER_1));
+		assertEquals(1, countOccurrences(loadFile(pathToDoc), CAPTION_FOLDER_1));
+
+		assertThrows(Exception.class, () -> {
+
+			new DolphinPlaces(tmpdir).add(Path.of(PATH_FOLDER_1), CAPTION_FOLDER_1);
+
+		});
+
+		assertEquals(1, countOccurrences(loadFile(pathToDoc), UUID_FOLDER_1));
+		assertEquals(1, countOccurrences(loadFile(pathToDoc), CAPTION_FOLDER_1));
+	}
+
+	@Test
+	@DisplayName("Invalid characters in caption should be escaped")
+	public void invalidCharactersInCaptionShouldBeEscaped(@TempDir Path tmpdir) {
+
+		var pathToDoc = loadResourceToDir(RESOURCE_USER_PLACES, tmpdir);
+
+		assertEquals(0, countOccurrences(loadFile(pathToDoc), "&lt; &amp; &gt;"));
+
+		assertDoesNotThrow(() -> {
+
+			new DolphinPlaces(tmpdir).add(Path.of(PATH_FOLDER_1), "< & >");
+
+		});
+
+		assertEquals(1, countOccurrences(loadFile(pathToDoc), "&lt; &amp; &gt;"));
+	}
+
+	private Path loadResourceToDir(String source, Path targetDir)  {
+
+		try (var stream = this.getClass().getClassLoader().getResourceAsStream(source)) {
+
+			if (stream == null) {
+				throw new IOException("Resource not found: " + source);
+			}
+
+			Files.copy(stream, targetDir.resolve("user-places.xbel"));
+
+			return targetDir.resolve("user-places.xbel");
+
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to load resource: " + source, e);
+		}
+	}
+
+	private String loadFile(Path file) {
+
+		if (!Files.exists(file)) {
+			throw new RuntimeException("File does not exist: " + file);
+		}
+
+		try {
+			return Files.readString(file);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public int countOccurrences(String content, String searchString) {
+		int count = 0;
+		int index = 0;
+
+		while ((index = content.indexOf(searchString, index)) != -1) {
+			count++;
+			index += searchString.length();
+		}
+
+		return count;
 	}
 }

--- a/src/test/resources/quickaccess/dolphin/user-places-multiple-identical.xbel
+++ b/src/test/resources/quickaccess/dolphin/user-places-multiple-identical.xbel
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file simulates a valid bookmark file -->
+<!DOCTYPE xbel>
+<xbel xmlns:bookmark="http://www.freedesktop.org/standards/desktop-bookmarks" xmlns:kdepriv="http://www.kde.org/kdepriv"
+	  xmlns:mime="http://www.freedesktop.org/standards/shared-mime-info">
+	<bookmark href="file:///home/someuser/folder1">
+		<title>folder 1</title>
+		<info>
+			<metadata owner="http://freedesktop.org">
+				<bookmark:icon name="drive-harddisk-encrypted"/>
+			</metadata>
+			<metadata owner="https://cryptomator.org">
+				<id>c4b72799-ca67-4c2e-b727-99ca67dc2e5d</id>
+			</metadata>
+		</info>
+	</bookmark>
+	<bookmark href="file:///home/someuser/folder1">
+		<title>folder 1</title>
+		<info>
+			<metadata owner="http://freedesktop.org">
+				<bookmark:icon name="drive-harddisk-encrypted"/>
+			</metadata>
+			<metadata owner="https://cryptomator.org">
+				<id>43c6fdb9-626d-468e-86fd-b9626dc68e04d</id>
+			</metadata>
+		</info>
+	</bookmark>
+</xbel>

--- a/src/test/resources/quickaccess/dolphin/user-places-not-valid.xbel
+++ b/src/test/resources/quickaccess/dolphin/user-places-not-valid.xbel
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file simulates a invalid structure (see line 6 'brokenbookmark') which is not valid according to the XSD-->
+<!DOCTYPE xbel>
+<xbel xmlns:bookmark="http://www.freedesktop.org/standards/desktop-bookmarks" xmlns:kdepriv="http://www.kde.org/kdepriv"
+	  xmlns:mime="http://www.freedesktop.org/standards/shared-mime-info">
+	<brokenbookmark href="file:///home/someuser/folder1">
+		<title>folder 1</title>
+		<info>
+			<metadata owner="http://freedesktop.org">
+				<bookmark:icon name="drive-harddisk-encrypted"/>
+			</metadata>
+			<metadata owner="https://cryptomator.org">
+				<id>c4b72799-ca67-4c2e-b727-99ca67dc2e5d</id>
+			</metadata>
+		</info>
+	</brokenbookmark>
+	<bookmark href="file:///home/someuser/folder2">
+		<title>folder 2</title>
+		<info>
+			<metadata owner="http://freedesktop.org">
+				<bookmark:icon name="drive-harddisk-encrypted"/>
+			</metadata>
+			<metadata owner="https://cryptomator.org">
+				<id>50e2de06-d9c7-4f45-a2de-06d9c75f4523</id>
+			</metadata>
+		</info>
+	</bookmark>
+	<bookmark href="file:///home/someuser/folder3">
+		<title>folder 3</title>
+		<info>
+			<metadata owner="http://freedesktop.org">
+				<bookmark:icon name="drive-harddisk-encrypted"/>
+			</metadata>
+			<metadata owner="https://anotherapp.org">
+				<id>8ce76c5d-62b3-44c1-a76c-5d62b3a4c1f2</id>
+			</metadata>
+		</info>
+	</bookmark>
+</xbel>
+
+
+

--- a/src/test/resources/quickaccess/dolphin/user-places-not-well-formed.xbel
+++ b/src/test/resources/quickaccess/dolphin/user-places-not-well-formed.xbel
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file simulates a non well-formed document (see line 9 to 11)-->
+<!DOCTYPE xbel>
+<xbel xmlns:bookmark="http://www.freedesktop.org/standards/desktop-bookmarks" xmlns:kdepriv="http://www.kde.org/kdepriv"
+	  xmlns:mime="http://www.freedesktop.org/standards/shared-mime-info">
+	<brokenbookmark href="file:///home/someuser/folder1">
+		<title>folder 1</title>
+		<info>
+			metadata owner="http://freedesktop.org">
+				bookmark:icon name="drive-harddisk-encrypted"/>
+			/metadata>
+			<metadata owner="https://cryptomator.org">
+				<id>c4b72799-ca67-4c2e-b727-99ca67dc2e5d</id>
+			</metadata>
+		</info>
+	</brokenbookmark>
+	<bookmark href="file:///home/someuser/folder2">
+		<title>folder 2</title>
+		<info>
+			<metadata owner="http://freedesktop.org">
+				<bookmark:icon name="drive-harddisk-encrypted"/>
+			</metadata>
+			<metadata owner="https://cryptomator.org">
+				<id>50e2de06-d9c7-4f45-a2de-06d9c75f4523</id>
+			</metadata>
+		</info>
+	</bookmark>
+	<bookmark href="file:///home/someuser/folder3">
+		<title>folder 3</title>
+		<info>
+			<metadata owner="http://freedesktop.org">
+				<bookmark:icon name="drive-harddisk-encrypted"/>
+			</metadata>
+			<metadata owner="https://anotherapp.org">
+				<id>8ce76c5d-62b3-44c1-a76c-5d62b3a4c1f2</id>
+			</metadata>
+		</info>
+	</bookmark>
+</xbel>

--- a/src/test/resources/quickaccess/dolphin/user-places.xbel
+++ b/src/test/resources/quickaccess/dolphin/user-places.xbel
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This file simulates a valid bookmark file -->
+<!DOCTYPE xbel>
+<xbel xmlns:bookmark="http://www.freedesktop.org/standards/desktop-bookmarks" xmlns:kdepriv="http://www.kde.org/kdepriv"
+	  xmlns:mime="http://www.freedesktop.org/standards/shared-mime-info">
+	<bookmark href="file:///home/someuser/folder1">
+		<title>folder 1</title>
+		<info>
+			<metadata owner="http://freedesktop.org">
+				<bookmark:icon name="drive-harddisk-encrypted"/>
+			</metadata>
+			<metadata owner="https://cryptomator.org">
+				<id>c4b72799-ca67-4c2e-b727-99ca67dc2e5d</id>
+			</metadata>
+		</info>
+	</bookmark>
+	<bookmark href="file:///home/someuser/folder2">
+		<title>folder 2</title>
+		<info>
+			<metadata owner="http://freedesktop.org">
+				<bookmark:icon name="drive-harddisk-encrypted"/>
+			</metadata>
+			<metadata owner="https://cryptomator.org">
+				<id>50e2de06-d9c7-4f45-a2de-06d9c75f4523</id>
+			</metadata>
+		</info>
+	</bookmark>
+	<bookmark href="file:///home/someuser/folder3">
+		<title>folder 3</title>
+		<info>
+			<metadata owner="http://freedesktop.org">
+				<bookmark:icon name="drive-harddisk-encrypted"/>
+			</metadata>
+			<metadata owner="https://anotherapp.org">
+				<id>8ce76c5d-62b3-44c1-a76c-5d62b3a4c1f2</id>
+			</metadata>
+		</info>
+	</bookmark>
+</xbel>


### PR DESCRIPTION
This commit refactors the Dolphin quick access integration to use DOM manipulation for adding and removing bookmarks in the XBEL file. This change aims to improve the reliability and correctness of bookmark management by handling stale entries.

Changes

- Replaces string-based manipulation of the XBEL file with DOM manipulation using org.w3c.dom.
- Introduces methods for loading, validating, and writing the XBEL document.
- Implements bookmark creation and removal using XPath queries and DOM operations.
- Adds more test cases to DolphinPlacesTest to cover adding and removing bookmarks under different scenarios.

Impact

- Improves the robustness of the Dolphin quick access integration by using standard XML parsing and manipulation techniques.
- The tests are modified to verify correct bookmark management.

Fixes: https://github.com/cryptomator/cryptomator/issues/3883