### PR TITLE
Bump secret service to 1.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<jackson.version>2.21.1</jackson.version>
 		<secret-service.version>2.0.1-alpha</secret-service.version>
 		<kdewallet.version>1.4.0</kdewallet.version>
-		<secret-service-02.version>1.1.0</secret-service-02.version>
+		<secret-service-02.version>1.1.1</secret-service-02.version>
 		<flatpakupdateportal.version>1.1.1</flatpakupdateportal.version>
 		<appindicator.version>1.4.2</appindicator.version>
 


### PR DESCRIPTION
This updates to the latest version of the secret service library.

It now logs a failure due to a missing keychain back end instead of throwing an IllegalStateException. 

Besides that, contained libraries were updated.